### PR TITLE
Fix duplicate function names

### DIFF
--- a/Modulo2-Closures/loops.js
+++ b/Modulo2-Closures/loops.js
@@ -33,7 +33,7 @@ anotherFunction();
 //que solamente lo imprimía, en cambio con let el closure si recuerda
 //en el bloque que fue declarada. Y por ende la ejecuta correctamente.
 
-const anotherFunction = () => {
+const anotherFunctionLet = () => {
   for (let i = 0; i < 10; i++) {
     setTimeout(() => {
       console.log(i);
@@ -41,7 +41,7 @@ const anotherFunction = () => {
   }
 };
 
-anotherFunction();
+anotherFunctionLet();
 
 // 0
 // 1


### PR DESCRIPTION
## Summary
- ensure loops example uses unique function names to avoid redefinitions

## Testing
- `node -e "console.log('test run');"` *(no tests provided)*

------
https://chatgpt.com/codex/tasks/task_b_6862e3f85660832dbe4f5b54051ab8e8